### PR TITLE
Classification Improvements

### DIFF
--- a/Source/Revit.IFC.Common/Utility/IFCAnyHandleUtil.cs
+++ b/Source/Revit.IFC.Common/Utility/IFCAnyHandleUtil.cs
@@ -1630,6 +1630,30 @@ namespace Revit.IFC.Common.Utility
          }
       }
 
+      public static void AssociatesAddRelated(IFCAnyHandle relAssociates, IFCAnyHandle related)
+      {
+         if (relAssociates == null)
+            throw new ArgumentNullException("IfcRelAssociates");
+
+         if (related == null)
+            throw new ArgumentNullException("IfcRelAssociates related");
+
+         if (!relAssociates.HasValue)
+            throw new ArgumentException("Invalid handle.");
+
+         if (!IsSubTypeOf(relAssociates, IFCEntityType.IfcRelAssociatesClassification))
+            throw new ArgumentException("The operation is not valid for this handle.");
+
+         IFCAggregate aggregate = relAssociates.GetAttribute("RelatedObjects").AsAggregate();
+         if (aggregate == null)
+         {
+            relAssociates.SetAttribute("RelatedObjects", new List<IFCAnyHandle>() { related });
+         }
+         else
+         {
+            aggregate.Add(IFCData.CreateIFCAnyHandle(related));
+         }
+      }
       /// <summary>
       /// Gets Name of an IfcProductDefinitionShape handle.
       /// </summary>

--- a/Source/Revit.IFC.Export/Revit.IFC.Export.csproj
+++ b/Source/Revit.IFC.Export/Revit.IFC.Export.csproj
@@ -195,6 +195,7 @@
     <Compile Include="Utility\ClassificationLocationCache.cs" />
     <Compile Include="Utility\ClassificationCache.cs" />
     <Compile Include="Utility\ContainmentCache.cs" />
+    <Compile Include="Utility\ClassificationReferenceCache.cs" />
     <Compile Include="Utility\CurveAnnotationCache.cs" />
     <Compile Include="Exporter\FamilyInstanceExporter.cs" />
     <Compile Include="Exporter\PropertySet\Description.cs" />

--- a/Source/Revit.IFC.Export/Utility/ClassificationCache.cs
+++ b/Source/Revit.IFC.Export/Utility/ClassificationCache.cs
@@ -34,6 +34,9 @@ namespace Revit.IFC.Export.Utility
    /// </summary>
    public class ClassificationCache
    {
+      private bool m_UniformatOverridden = false;
+      public bool UniformatOverriden { get { return m_UniformatOverridden; } }
+
       private IDictionary<string, IFCAnyHandle> m_ClassificationHandles = null;
 
       /// <summary>
@@ -116,6 +119,8 @@ namespace Revit.IFC.Export.Utility
                   {
                      // found [<Classification Field Names>]
                      string classificationFieldName = splitResult[ii].Trim();
+                     if (string.Compare("Assembly Code", classificationFieldName, true) == 0)
+                        m_UniformatOverridden = true;
                      CustomClassificationCodeNames.Add(classificationFieldName);
                      if (classificationHasName)
                         FieldNameToClassificationNames[classificationFieldName] = classification.ClassificationName;

--- a/Source/Revit.IFC.Export/Utility/ClassificationReferenceCache.cs
+++ b/Source/Revit.IFC.Export/Utility/ClassificationReferenceCache.cs
@@ -1,0 +1,78 @@
+﻿//
+// BIM IFC library: this library works with Autodesk(R) Revit(R) to export IFC files containing model geometry.
+// Copyright (C) 2012  Autodesk, Inc.
+// 
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.IFC;
+
+namespace Revit.IFC.Export.Utility
+{
+   /// <summary>
+   /// Used to keep a cache of the Classification Reference IfcRelAssociatesClassification handles.
+   /// </summary>
+   public class ClassificationReferenceCache
+   {
+      struct ClassificationReferenceKey
+      {
+         /// <summary>
+         /// The classification Name.
+         /// </summary>
+         public string ClassificationId;
+         /// <summary>
+         /// The Classification Reference Code.
+         /// </summary>
+         public string ClassificationReferenceCode;
+      }
+
+      Dictionary<ClassificationReferenceKey, IFCAnyHandle> classificationReferenceMap;
+      public ClassificationReferenceCache()
+      {
+         classificationReferenceMap = new Dictionary<ClassificationReferenceKey, IFCAnyHandle>();
+      }
+
+      public IFCAnyHandle GetClassificationReferenceAssociation(string classificationName, string classificationReferenceCode)
+      {
+         IFCAnyHandle classificationReferenceHandle;
+         ClassificationReferenceKey key = new ClassificationReferenceKey() { ClassificationId = classificationName, ClassificationReferenceCode = classificationReferenceCode };
+         if (classificationReferenceMap.TryGetValue(key, out classificationReferenceHandle))
+         {
+            return classificationReferenceHandle;
+         }
+         else
+         {
+            return null;
+         }
+      }
+
+      public void AddClassificationReferenceAssociation(string classificationName, string classificationReferenceCode, IFCAnyHandle classificationReferenceAssociation)
+      {
+         ClassificationReferenceKey key = new ClassificationReferenceKey() { ClassificationId = classificationName, ClassificationReferenceCode = classificationReferenceCode };
+
+         if (classificationReferenceMap.ContainsKey(key))
+         {
+            throw new Exception("classificationReferenceCache already contains this classificationReferenceKey");
+         }
+
+         classificationReferenceMap[key] = classificationReferenceAssociation;
+      }
+   }
+}

--- a/Source/Revit.IFC.Export/Utility/ExporterCacheManager.cs
+++ b/Source/Revit.IFC.Export/Utility/ExporterCacheManager.cs
@@ -77,6 +77,7 @@ namespace Revit.IFC.Export.Utility
       /// </summary>
       static ClassificationLocationCache m_ClassificationLocationCache;
 
+      static ClassificationReferenceCache m_ClassificationReferenceCache;
       /// <summary>
       /// The ContainmentCache object.
       /// </summary>
@@ -1055,6 +1056,17 @@ public static ParameterCache ParameterCache
          set { m_ClassificationLocationCache = value; }
       }
 
+      public static ClassificationReferenceCache ClassificationReferenceCache
+      {
+         get
+         {
+            if (m_ClassificationReferenceCache == null)
+               m_ClassificationReferenceCache = new ClassificationReferenceCache();
+            return m_ClassificationReferenceCache;
+         }
+         set { m_ClassificationReferenceCache = value; }
+      }
+
       /// <summary>
       /// The UnitsCache object.
       /// </summary>
@@ -1297,6 +1309,7 @@ public static ParameterCache ParameterCache
          m_CeilingSpaceRelCache = null;
          m_ClassificationCache = null;
          m_ClassificationLocationCache = null;
+         m_ClassificationReferenceCache = null;
          m_ConditionalPropertySetsForTypeCache = null;
          m_ContainmentCache = null;
          m_CurveAnnotationCache = null;


### PR DESCRIPTION
Classification References cached so that they are reused.
Creation of Uniformat classification suppressed if "Assembly Code" nominated as user classification source parameter
