### PR TITLE
Improve VolumetricFlowRate Unit nomination

### DIFF
--- a/Source/Revit.IFC.Export/Exporter/Exporter.cs
+++ b/Source/Revit.IFC.Export/Exporter/Exporter.cs
@@ -3251,7 +3251,7 @@ namespace Revit.IFC.Export.Exporter
             double volumetricFlowRateFactor = UnitUtils.ConvertFromInternalUnits(1.0, forgeTypeId);
 
             ISet<IFCAnyHandle> elements = new HashSet<IFCAnyHandle>();
-            elements.Add(IFCInstanceExporter.CreateDerivedUnitElement(file, lenSIBaseUnit, 3));
+            elements.Add(IFCInstanceExporter.CreateDerivedUnitElement(file, volumetricFlowRateLenUnit, 3));
             elements.Add(IFCInstanceExporter.CreateDerivedUnitElement(file, timeSIUnit, -1));
 
             IFCAnyHandle volumetricFlowRateUnit = IFCInstanceExporter.CreateDerivedUnit(file, elements,


### PR DESCRIPTION
VOLUMETRICFLOWRATEUNIT was using SI length unit in derived unit when it shouldn't for L/S