### PR TITLE
Improvements for schedule exporting

### DIFF
--- a/Source/IFCExporterUIOverride/IFCExporterUIOverride.csproj
+++ b/Source/IFCExporterUIOverride/IFCExporterUIOverride.csproj
@@ -54,19 +54,19 @@
   <ItemGroup>
     <Reference Include="Autodesk.UI.Windows, Version=2.8.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\Program Files\Autodesk\Revit 2021\Autodesk.UI.Windows.dll</HintPath>
+      <HintPath>C:\Program Files\Autodesk\Revit 2021\Autodesk.UI.Windows.dll</HintPath>
     </Reference>
     <Reference Include="RevitAPI, Version=21.0.0.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\Program Files\Autodesk\Revit 2021\RevitAPI.dll</HintPath>
+		<HintPath>C:\Program Files\Autodesk\Revit 2021\RevitAPI.dll</HintPath>
     </Reference>
     <Reference Include="RevitAPIIFC, Version=21.0.0.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\Program Files\Autodesk\Revit 2021\RevitAPIIFC.dll</HintPath>
+      <HintPath>C:\Program Files\Autodesk\Revit 2021\RevitAPIIFC.dll</HintPath>
     </Reference>
     <Reference Include="RevitAPIUI, Version=21.0.0.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\Program Files\Autodesk\Revit 2021\RevitAPIUI.dll</HintPath>
+      <HintPath>C:\Program Files\Autodesk\Revit 2021\RevitAPIUI.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
@@ -84,7 +84,7 @@
     </Reference>
     <Reference Include="UserInterfaceUtility, Version=21.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\Program Files\Autodesk\Revit 2021\UserInterfaceUtility.dll</HintPath>
+      <HintPath>C:\Program Files\Autodesk\Revit 2021\UserInterfaceUtility.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />

--- a/Source/Revit.IFC.Export/Exporter/ExporterInitializer.cs
+++ b/Source/Revit.IFC.Export/Exporter/ExporterInitializer.cs
@@ -458,7 +458,7 @@ namespace Revit.IFC.Export.Exporter
 
             PropertySetDescription customPSet = new PropertySetDescription();
 
-            string scheduleName = schedule.Name;
+            string scheduleName = NamingUtil.GetNameOverride(schedule, schedule.Name);
             if (string.IsNullOrWhiteSpace(scheduleName))
             {
                scheduleName = "Unnamed Schedule " + unnamedScheduleIndex;
@@ -494,6 +494,9 @@ namespace Revit.IFC.Export.Exporter
             for (int ii = 0; ii < fieldCount; ii++)
             {
                ScheduleField field = definition.GetField(ii);
+
+               if (field.IsHidden)
+                  continue;
 
                ScheduleFieldType fieldType = field.FieldType;
                if (fieldType != ScheduleFieldType.Instance && fieldType != ScheduleFieldType.ElementType)

--- a/Source/RevitIFCTools/RevitIFCTools.csproj
+++ b/Source/RevitIFCTools/RevitIFCTools.csproj
@@ -56,7 +56,7 @@
   <ItemGroup>
     <Reference Include="RevitAPI, Version=21.1.0.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\Program Files\Autodesk\Revit 2021\RevitAPI.dll</HintPath>
+      <HintPath>C:\Program Files\Autodesk\Revit 2021\RevitAPI.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />


### PR DESCRIPTION
I have added two small improvements to the Pset export via schedules. Please consider these changes for integration.

**1. Skipping of hidden schedule fields**

The reason why I think this is important is that columns are often used for filtering. For instance you can create a schedule of all radiators by adding the IfcExportAs-parameter to the schedule and filter by the attribute value IfcSpaceHeaterType.RADIATOR. The export-classification is needed for filtering but is surely not something which I would want to see in my Pset. Following the WYSIWYG principle, hidden columns are unexpected by the user and thus should not be exported.

**2. Using name override for Pset names**

This comes in handy when we use IfcExportAs=DontExport on schedules to control which Psets are actually exported instead of relying on a name-prefix like Pset, IFC or the like. In this way I can opt-in to give a meaningful Pset-name that does not necessarily align with the schedules view name.

The important changes are in d9364cd, the other one is just an attempt to make HintPaths more consistent with the other projects, since the relative paths do not work everywhere.

Keep up the work and contact me in case you have any questions.
