### PR TITLE
New option: ExportAllPhases, ignores phases and exports all elements

### DIFF
--- a/Source/IFCExporterUIOverride/IFCExportConfiguration.cs
+++ b/Source/IFCExporterUIOverride/IFCExportConfiguration.cs
@@ -301,16 +301,21 @@ namespace BIM.IFC.Export.UI
          /// </summary>
          public bool UseVisibleRevitNameAsEntityName { get; set; } = false;
 
+         /// <summary>
+         /// Value indicating whether to export all phases in the view or not
+         /// </summary>
+         public bool ExportAllPhases { get; set; } = false;
+
       #endregion  // AdvancedTab
 
 
       // Items under Entities to Export Tab
       #region EntitiesToExportTab
 
-         /// <summary>
-         /// Exclude filter string (element list in an arrary, seperated with semicolon ';')
-         /// </summary>
-         public string ExcludeFilter { get; set; } = "";
+      /// <summary>
+      /// Exclude filter string (element list in an arrary, seperated with semicolon ';')
+      /// </summary>
+      public string ExcludeFilter { get; set; } = "";
 
       #endregion  // EntitiesToExportTab
 

--- a/Source/IFCExporterUIOverride/IFCExportConfigurationsMap.cs
+++ b/Source/IFCExporterUIOverride/IFCExportConfigurationsMap.cs
@@ -194,6 +194,8 @@ namespace BIM.IFC.Export.UI
                      configuration.UseTypeNameOnlyForIfcType = bool.Parse(configMap[s_useTypeNameOnlyForIfcType]);
                   if (configMap.ContainsKey(s_useVisibleRevitNameAsEntityName))
                      configuration.UseVisibleRevitNameAsEntityName = bool.Parse(configMap[s_useVisibleRevitNameAsEntityName]);
+                  if (configMap.ContainsKey(s_exportAllPhases))
+                     configuration.ExportAllPhases = bool.Parse(configMap[s_exportAllPhases]);
                   if (configMap.ContainsKey(s_useOnlyTriangulation))
                      configuration.UseOnlyTriangulation = bool.Parse(configMap[s_useOnlyTriangulation]);
                   if (configMap.ContainsKey(s_setupTessellationLevelOfDetail))
@@ -296,6 +298,9 @@ namespace BIM.IFC.Export.UI
                   Field fieldUseVisibleRevitNameAsEntityName = m_schema.GetField(s_useVisibleRevitNameAsEntityName);
                   if (fieldUseVisibleRevitNameAsEntityName != null)
                      configuration.UseVisibleRevitNameAsEntityName = configEntity.Get<bool>(s_useVisibleRevitNameAsEntityName);
+                  Field fieldExportAllPhases = m_schema.GetField(s_exportAllPhases);
+                  if (fieldExportAllPhases != null)
+                     configuration.ExportAllPhases = configEntity.Get<bool>(s_exportAllPhases);
                   Field fieldTessellationLevelOfDetail = m_schema.GetField(s_setupTessellationLevelOfDetail);
                   if (fieldTessellationLevelOfDetail != null)
                      configuration.TessellationLevelOfDetail = configEntity.Get<double>(s_setupTessellationLevelOfDetail);
@@ -349,6 +354,7 @@ namespace BIM.IFC.Export.UI
       private const string s_setupSitePlacement = "SitePlacement";
       private const string s_useTypeNameOnlyForIfcType = "UseTypeNameOnlyForIfcType";
       private const string s_useVisibleRevitNameAsEntityName = "UseVisibleRevitNameAsEntityName";
+      private const string s_exportAllPhases = "ExportAllPhases";
       // Used for COBie 2.4
       private const string s_cobieCompanyInfo = "COBieCompanyInfo";
       private const string s_cobieProjectInfo = "COBieProjectInfo";

--- a/Source/IFCExporterUIOverride/IFCExporterUIWindow.xaml
+++ b/Source/IFCExporterUIOverride/IFCExporterUIWindow.xaml
@@ -65,6 +65,7 @@
                <CheckBox Content="{x:Static p:Resources.ExportLinkedFiles}" Margin="10,29,0,0" x:Name="checkBoxExportLinkedFiles" Checked="checkBoxExportLinkedFiles_Checked" Unchecked="checkBoxExportLinkedFiles_Checked" HorizontalAlignment="Left" Width="570" Height="16" VerticalAlignment="Top" />
                <CheckBox Content="{x:Static p:Resources.ExportVisibleElementsInView}" Margin="10,50,0,0" Name="checkboxVisibleElementsCurrView" Checked="checkboxVisibleElementsCurrView_Checked" Unchecked="checkboxVisibleElementsCurrView_Checked" RenderTransformOrigin="0.634,0.968" HorizontalAlignment="Left" Width="570" Height="16" VerticalAlignment="Top" />
                <CheckBox Content="{x:Static p:Resources.ExportRoomsInView}" x:Name="checkBoxExportRoomsInView" Checked="checkBoxExportRoomsInView_Checked" Unchecked="checkBoxExportRoomsInView_Checked" IsEnabled="False" Margin="30,71,0,0" HorizontalAlignment="Left" Width="550" Height="16" VerticalAlignment="Top" />
+               <CheckBox Content="{x:Static p:Resources.ExportAllPhases}" HorizontalAlignment="Left" x:Name="checkBoxExportAllPhases" VerticalAlignment="Top" Checked="checkBoxExportAllPhases_Checked" Unchecked="checkBoxExportAllPhases_Checked" Height="16" Width="567" Margin="10,90,0,0" Grid.ColumnSpan="5" />
             </Grid>
          </TabItem>
          <TabItem Header="{x:Static p:Resources.PropertySets}"  x:Name="PropertySets">

--- a/Source/IFCExporterUIOverride/IFCExporterUIWindow.xaml.cs
+++ b/Source/IFCExporterUIOverride/IFCExporterUIWindow.xaml.cs
@@ -257,7 +257,7 @@ namespace BIM.IFC.Export.UI
             }
          }
 
-         comboboxActivePhase.IsEnabled = !configuration.VisibleElementsOfCurrentView;
+         comboboxActivePhase.IsEnabled = !(configuration.VisibleElementsOfCurrentView || configuration.ExportAllPhases);
       }
 
       /// <summary>
@@ -326,6 +326,7 @@ namespace BIM.IFC.Export.UI
          checkboxIncludeIfcSiteElevation.IsChecked = configuration.IncludeSiteElevation;
          checkboxStoreIFCGUID.IsChecked = configuration.StoreIFCGUID;
          checkBoxExportRoomsInView.IsChecked = configuration.ExportRoomsInView;
+         checkBoxExportAllPhases.IsChecked = configuration.ExportAllPhases;
          comboBoxLOD.SelectedIndex = (int)(Math.Round(configuration.TessellationLevelOfDetail * 4) - 1);
          checkboxIncludeSteelElements.IsChecked = configuration.IncludeSteelElements;
          comboBoxSitePlacement.SelectedIndex = (int)configuration.SitePlacement;
@@ -373,6 +374,7 @@ namespace BIM.IFC.Export.UI
                                                                 checkboxExportSchedulesAsPsets,
                                                                 checkBoxExportSpecificSchedules,
                                                                 checkBoxExportRoomsInView,
+                                                                checkBoxExportAllPhases,
                                                                 checkBoxLevelOfDetails,
                                                                 comboboxActivePhase,
                                                                 checkboxExportUserDefinedPset,
@@ -393,7 +395,7 @@ namespace BIM.IFC.Export.UI
          {
             element.IsEnabled = !configuration.IsBuiltIn;
          }
-         comboboxActivePhase.IsEnabled = comboboxActivePhase.IsEnabled && !configuration.VisibleElementsOfCurrentView;
+         comboboxActivePhase.IsEnabled = comboboxActivePhase.IsEnabled && !(configuration.VisibleElementsOfCurrentView || configuration.ExportAllPhases);
          userDefinedPropertySetFileName.IsEnabled = userDefinedPropertySetFileName.IsEnabled && configuration.ExportUserDefinedPsets;
          userDefinedParameterMappingTable.IsEnabled = userDefinedParameterMappingTable.IsEnabled && configuration.ExportUserDefinedParameterMapping;
          buttonBrowse.IsEnabled = buttonBrowse.IsEnabled && configuration.ExportUserDefinedPsets;
@@ -1408,6 +1410,17 @@ namespace BIM.IFC.Export.UI
          if (configuration != null)
          {
             configuration.ExportRoomsInView = GetCheckbuttonChecked(checkBox);
+         }
+      }
+
+      private void checkBoxExportAllPhases_Checked(object sender, RoutedEventArgs e)
+      {
+         CheckBox checkBox = (CheckBox)sender;
+         IFCExportConfiguration configuration = GetSelectedConfiguration();
+         if (configuration != null)
+         {
+            configuration.ExportAllPhases = GetCheckbuttonChecked(checkBox);
+            UpdatePhaseAttributes(configuration);
          }
       }
 

--- a/Source/IFCExporterUIOverride/Properties/Resources.Designer.cs
+++ b/Source/IFCExporterUIOverride/Properties/Resources.Designer.cs
@@ -619,6 +619,15 @@ namespace BIM.IFC.Export.UI.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Export all elements regardless of phase.
+        /// </summary>
+        public static string ExportAllPhases {
+            get {
+                return ResourceManager.GetString("ExportAllPhases", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Export base quantities.
         /// </summary>
         public static string ExportBaseQuantities {

--- a/Source/IFCExporterUIOverride/Properties/Resources.de.resx
+++ b/Source/IFCExporterUIOverride/Properties/Resources.de.resx
@@ -399,6 +399,9 @@
   <data name="Export" xml:space="preserve">
     <value>Export</value>
   </data>
+  <data name="ExportAllPhases" xml:space="preserve">
+    <value>Alle Elemente unabhängig von der Phase exportieren</value>
+  </data>
   <data name="ExportElementsVisibleInView" xml:space="preserve">
     <value>Nur in der Ansicht sichtbare Elemente exportieren</value>
   </data>

--- a/Source/IFCExporterUIOverride/Properties/Resources.fr.resx
+++ b/Source/IFCExporterUIOverride/Properties/Resources.fr.resx
@@ -402,6 +402,9 @@
   <data name="Export" xml:space="preserve">
     <value>Exporter…</value>
   </data>
+  <data name="ExportAllPhases" xml:space="preserve">
+    <value>Exporter tous les éléments, quelle que soit la phase</value>
+  </data>
   <data name="ExportElementsVisibleInView" xml:space="preserve">
     <value>Exporter uniquement les éléments visibles  dans la vue actuelle</value>
   </data>

--- a/Source/IFCExporterUIOverride/Properties/Resources.resx
+++ b/Source/IFCExporterUIOverride/Properties/Resources.resx
@@ -374,6 +374,9 @@
   <data name="Export" xml:space="preserve">
     <value>Export</value>
   </data>
+  <data name="ExportAllPhases" xml:space="preserve">
+    <value>Export all elements regardless of phase</value>
+  </data>
   <data name="ExportElementsVisibleInView" xml:space="preserve">
     <value>Export only elements visible in current view</value>
   </data>

--- a/Source/Revit.IFC.Common/Revit.IFC.Common.csproj
+++ b/Source/Revit.IFC.Common/Revit.IFC.Common.csproj
@@ -52,17 +52,33 @@
     <DefineConstants>TRACE;IFC_OPENSOURCE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="RevitAPI, Version=22.0.0.0, Culture=neutral, processorArchitecture=AMD64">
+    <Reference Include="AdWindows, Version=3.1.7.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Revit_All_Main_Versions_API_x64.2022.1.0\lib\net48\AdWindows.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Program Files\Autodesk\Revit 2022\RevitAPI.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="RevitAPI, Version=22.0.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Revit_All_Main_Versions_API_x64.2022.1.0\lib\net48\RevitAPI.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
     </Reference>
     <Reference Include="RevitAPIIFC, Version=22.0.0.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>C:\Program Files\Autodesk\Revit 2022\RevitAPIIFC.dll</HintPath>
     </Reference>
+    <Reference Include="RevitAPIUI, Version=22.0.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Revit_All_Main_Versions_API_x64.2022.1.0\lib\net48\RevitAPIUI.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.XML" />
+    <Reference Include="UIFramework, Version=22.0.0.0, Culture=neutral, processorArchitecture=AMD64">
+      <HintPath>..\..\packages\Revit_All_Main_Versions_API_x64.2022.1.0\lib\net48\UIFramework.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Enums\CommonEnum.cs" />
@@ -115,6 +131,9 @@
       <ProductName>Windows Installer 3.1</ProductName>
       <Install>true</Install>
     </BootstrapperPackage>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project=".\Revit.IFC.Common.props" />
   <PropertyGroup>

--- a/Source/Revit.IFC.Export/Utility/ElementFilteringUtil.cs
+++ b/Source/Revit.IFC.Export/Utility/ElementFilteringUtil.cs
@@ -99,7 +99,7 @@ namespace Revit.IFC.Export.Utility
          filters.Add(GetDesignOptionFilter());
 
          // Phases: only for non-spatial elements.  For spatial elements, we will do a check afterwards.
-         if (!forSpatialElements && !ExporterCacheManager.ExportOptionsCache.ExportingLink)
+         if (!forSpatialElements && !ExporterCacheManager.ExportOptionsCache.ExportingLink && !ExporterCacheManager.ExportOptionsCache.ExportAllPhases)
             filters.Add(GetPhaseStatusFilter(document));
 
          return new LogicalAndFilter(filters);
@@ -558,6 +558,8 @@ namespace Revit.IFC.Export.Utility
             Parameter phaseParameter = element.get_Parameter(BuiltInParameter.ROOM_PHASE);
             if (phaseParameter != null)
             {
+               if (ExporterCacheManager.ExportOptionsCache.ExportAllPhases)
+                  return true;
                ElementId phaseId = phaseParameter.AsElementId();
                if (phaseId != ElementId.InvalidElementId && phaseId != ExporterCacheManager.ExportOptionsCache.ActivePhaseId)
                   return true;

--- a/Source/Revit.IFC.Export/Utility/ExportOptionsCache.cs
+++ b/Source/Revit.IFC.Export/Utility/ExportOptionsCache.cs
@@ -372,6 +372,9 @@ namespace Revit.IFC.Export.Utility
             cache.ActiveView = activeView;
          }
 
+         bool? exportAllPhases = OptionsUtil.GetNamedBooleanOption(options, "ExportAllPhases");
+         cache.ExportAllPhases = exportAllPhases.HasValue ? exportAllPhases.Value : false;
+
          // "FileType" - note - setting is not respected yet
          ParseFileType(options, cache);
 
@@ -724,6 +727,16 @@ namespace Revit.IFC.Export.Utility
       /// False to use default export options.
       /// </summary>
       public bool UseActiveViewGeometry
+      {
+         get;
+         set;
+      }
+
+      /// <summary>
+      /// True to export all elements regardless of phase
+      /// False to use default export options.
+      /// </summary>
+      public bool ExportAllPhases
       {
          get;
          set;


### PR DESCRIPTION
This option adds a new option to the export settings which allows you to not be limited by Revit's phase system to export elements. So you can export multiple phases (if you set up your view correctly) or export all phases. Selecting this option will grey out the "PhaseToExport" combobox.

![image](https://user-images.githubusercontent.com/13383284/157457465-b4ed82fd-01f1-40d9-adbb-a4db92ebaf22.png)

This was needed for work and figured that this may come in handy for more people.
As far as I know, everything is accounted for. You can also use the option "ExportAllPhases" with option "true" to enable it using python Dynamo.