### PR TITLE
Error caused by invalid handles...

### DIFF
--- a/Source/Revit.IFC.Common/Utility/IFCAnyHandleUtil.cs
+++ b/Source/Revit.IFC.Common/Utility/IFCAnyHandleUtil.cs
@@ -1937,7 +1937,21 @@ namespace Revit.IFC.Common.Utility
       /// <returns>True if it is null or has no value, false otherwise.</returns>
       public static bool IsNullOrHasNoValue(IFCAnyHandle handle)
       {
-         return handle == null || !handle.HasValue;
+         if (handle == null || !handle.HasValue)
+            return true;
+
+         // Temporary code for 2022 until HasValue is set propertly when handle has become invalid
+         bool staleHandle = false;
+         try
+         {
+            string entityTypeName = handle.TypeName;
+         }
+         catch
+         {
+            staleHandle = true;
+         }
+
+         return staleHandle;
       }
 
       /// <summary>


### PR DESCRIPTION
that appear after rollBack in EDM-based Revit (2022.0.1). Additional TypeName check helps to define and remove them correctly.