### PR TITLE
Fix material colors for pipe/duct fittings (swept solids and shared types)

### DIFF
--- a/Source/Revit.IFC.Export/Exporter/BodyExporter.cs
+++ b/Source/Revit.IFC.Export/Exporter/BodyExporter.cs
@@ -337,7 +337,13 @@ namespace Revit.IFC.Export.Exporter
             categoryValue == (long)BuiltInCategory.OST_Walls;
       }
 
-      private static ElementId GetBestMaterialIdFromParameter(Element element)
+      /// <summary>
+      /// Gets the best material id from the element parameters, including the material of
+      /// the MEP system type for duct and pipe elements.
+      /// </summary>
+      /// <param name="element">The element.</param>
+      /// <returns>The material id, or InvalidElementId if not found.</returns>
+      public static ElementId GetBestMaterialIdFromParameter(Element element)
       {
          if (element == null)
          {
@@ -4086,7 +4092,7 @@ namespace Revit.IFC.Export.Exporter
 
                               if (bodyItems.AddIfNotNull(sweptHandle))
                               {
-                                 ElementId matId = exporterIFC.GetMaterialIdForCurrentExportState();
+                                 ElementId matId = SetBestMaterialIdInExporter(solid, element, overrideMaterialId, exporterIFC);
                                  materialIdsForExtrusions.Add(matId);
                                  GraphicsStyle style = document.GetElement(solid.GraphicsStyleId) as GraphicsStyle;
                                  bodyData.AddRepresentationItemInfo(document, style, matId, sweptHandle);

--- a/Source/Revit.IFC.Export/Exporter/FamilyInstanceExporter.cs
+++ b/Source/Revit.IFC.Export/Exporter/FamilyInstanceExporter.cs
@@ -607,9 +607,16 @@ namespace Revit.IFC.Export.Exporter
          bool flipped = doorWindowInfo?.FlippedSymbol ?? false;
          ElementId overrideMaterialId = ExporterUtil.GetSingleMaterial(familyInstance);
 
+         // The material of a shared symbol may be resolved from the instance, e.g. from the
+         // MEP system type for fittings.  Include it in the key so that instances with
+         // different resolved materials don't reuse a type styled with another instance's
+         // material.
+         ElementId keyMaterialId = (overrideMaterialId != ElementId.InvalidElementId) ?
+            overrideMaterialId : BodyExporter.GetBestMaterialIdFromParameter(familyInstance);
+
          bool containedInAssembly = ExporterUtil.IsContainedInAssembly(familyInstance);
          var typeKey = new TypeObjectKey(originalFamilySymbol.Id,
-            overrideLevelId, flipped, exportType, overrideMaterialId, containedInAssembly);
+            overrideLevelId, flipped, exportType, keyMaterialId, containedInAssembly);
 
          FamilyTypeInfo currentTypeInfo = 
             ExporterCacheManager.FamilySymbolToTypeInfoCache.Find(typeKey);


### PR DESCRIPTION
## Summary

Fittings are often exported with the wrong color or no color at all.
This PR fixes two causes of that:

- Fixes #915 — fittings with geometry swept along an arc export grey in
  IFC4x3 (and IFC4 DTV). System materials and IfcSingleMaterialOverride
  are ignored; only object-style colors survive.
- Fixes #373 — when the same fitting type is used in several systems
  (e.g. blue Supply Air and orange Return Air), every fitting gets the
  color of whichever system was exported first.
- Should also largely resolve #112 — fittings now pick up the material
  of their piping/duct system type, per system. (Display-only "Graphic
  Overrides" are still not exported, and family-defined materials still
  take precedence, as today.)

## Root causes

1. In `BodyExporter.ExportBody`, the swept-solid branch takes its
   material from `exporterIFC.GetMaterialIdForCurrentExportState()`,
   but that state is only ever set in the extrusion and BRep branches.
   A sweep along an arc sets nothing, so the
   `IfcSurfaceCurveSweptAreaSolid` is written without an
   `IfcSurfaceStyle` and viewers show it grey. Straight sweeps are
   unaffected because they are handled as plain extrusions, and
   IFC4/IFC2x3 are unaffected because the geometry is tessellated
   there, which resolves the color independently.

2. In `FamilyInstanceExporter.ExportFamilyInstanceAsMappedItem`, the
   type representation (including its IfcStyledItem colors) is cached
   in `FamilySymbolToTypeInfoCache`. The cache key does not include the
   material resolved from the instance (e.g. the MEP system type
   material), so the first instance's color is baked into the shared
   `IfcRepresentationMap` and reused by all instances of that symbol,
   regardless of their system.

## Changes

- `BodyExporter.cs`: resolve the material in the swept-solid branch
  with the same `SetBestMaterialIdInExporter` call the extrusion branch
  uses (honors geometry material, instance/system parameters, and
  IfcSingleMaterialOverride). Made `GetBestMaterialIdFromParameter`
  public.
- `FamilyInstanceExporter.cs`: include the instance-resolved material
  in `TypeObjectKey`, so one symbol used with different materials
  produces separate, correctly styled type products.

## Notes for reviewers

- Type GUIDs change for families whose instances resolve a material
  from parameters, because the type GUID is derived from the cache key.
  This is inherent to splitting one symbol into several types.
- Reproduction files are attached to #915 (arc vs. straight sweep) and
  the scenario in #373 (one fitting type in two systems) shows the
  caching issue.